### PR TITLE
example implementation for learning curve generation

### DIFF
--- a/ccobra/benchmark/evaluator.py
+++ b/ccobra/benchmark/evaluator.py
@@ -905,11 +905,8 @@ class Split_Evaluator(Evaluator):
                     # split the individuals data in train and test set
                     perm = np.random.permutation(np.arange(len(subj_df)))
                     split_id = int(self.split_ratio * len(subj_df))
-                    train_ids, test_ids = subj_df[:split_id], subj_df[split_id:]
-
-                    print(train_ids, test_ids)
-                    print(self.split_ratio)
-                    exit()
+                    train_ids, test_ids = perm[:split_id], perm[split_id:]
+                    train_set, test_set = subj_df.iloc[train_ids], subj_df.iloc[test_ids]
 
                     # Iterate over individual tasks
                     for _, row in subj_df.sort_values('sequence').iterrows():

--- a/ccobra/benchmark/evaluator.py
+++ b/ccobra/benchmark/evaluator.py
@@ -708,4 +708,4 @@ class LC_Evaluator(Evaluator):
             plt.tight_layout()
             plt.savefig('{}/{}_{}.png'.format(self.learning_curves, model,
                                               phase))
-            plt.cla()
+            plt.clf()

--- a/ccobra/benchmark/evaluator.py
+++ b/ccobra/benchmark/evaluator.py
@@ -277,6 +277,7 @@ class Evaluator():
 
         # Activate model context
         for idx, modelitem in enumerate(self.modeldict.items()):
+            model_checkpoints = {}
             model, model_kwargs = modelitem
 
             # Print the progress

--- a/ccobra/benchmark/evaluator.py
+++ b/ccobra/benchmark/evaluator.py
@@ -389,6 +389,7 @@ class LC_Evaluator(Evaluator):
         super().__init__(*args, **kwargs)
         if learning_curves:
             learning_curves = learning_curves.rstrip('/')
+        assert os.path.isdir(learning_curves)
         self.learning_curves = learning_curves
 
     def evaluate(self):

--- a/ccobra/benchmark/evaluator.py
+++ b/ccobra/benchmark/evaluator.py
@@ -557,7 +557,7 @@ class LC_Evaluator(Evaluator):
                     if adapt_str in self.learning_curves_for:
                         model_evaluations[subj_id][adapt_str] = {}
 
-                    for _, row in subj_df.sort_values('sequence').iterrows():
+                    for r, (_, row) in enumerate(subj_df.sort_values('sequence').iterrows()):
                         optionals = self.extract_optionals(row)
 
                         # Evaluation
@@ -598,7 +598,8 @@ class LC_Evaluator(Evaluator):
                                 sequence] = self.evaluate_checkpoints(
                                 model_checkpoints, subj_id)
 
-                        if main_train_str in self.learning_curves_for:
+                        if (main_train_str in self.learning_curves_for
+                                and r % self.evaluation_frequency == 0):
                             model_evaluations[subj_id][
                                 main_train_str].append(
                                     self.evaluate_checkpoints(

--- a/ccobra/benchmark/evaluator.py
+++ b/ccobra/benchmark/evaluator.py
@@ -429,6 +429,7 @@ class LC_Evaluator(Evaluator):
         """
 
         result_data = []
+        model_name_cache = set()
 
         # Pre-compute the training data dictionaries
         train_data_dict = None
@@ -436,36 +437,46 @@ class LC_Evaluator(Evaluator):
             train_data_dict = self.get_train_data_dict(self.train_data)
 
         # Activate model context
-        for idx, modelitem in enumerate(self.modeldict.items()):
+        for idx, modelinfo in enumerate(self.modellist):
             model_evaluations = {}
-            model, model_kwargs = modelitem
-
             # Print the progress
             if not self.silent:
                 print("Evaluating '{}' ({}/{})...".format(
-                    model, idx + 1, len(self.modeldict)))
+                    modelinfo.path, idx + 1, len(self.modellist)))
 
             # Setup the model context
-            context = os.path.abspath(model)
+            context = os.path.abspath(modelinfo.path)
             if os.path.isfile(context):
                 context = os.path.dirname(context)
 
-            # Extract load_specific_class
-            specific_class = None
-            if 'load_specific_class' in model_kwargs:
-                specific_class = model_kwargs['load_specific_class']
-                del model_kwargs['load_specific_class']
-
             with dir_context(context):
+                # Dynamically import the CCOBRA model
                 importer = modelimporter.ModelImporter(
-                    model, ccobra.CCobraModel,
-                    load_specific_class=specific_class)
+                    modelinfo.path, ccobra.CCobraModel,
+                    load_specific_class=modelinfo.load_specific_class)
 
                 # Instantiate and prepare the model for predictions
-                pre_model = importer.instantiate(model_kwargs)
+                pre_model = importer.instantiate(modelinfo.args)
 
                 # Check if model is applicable to domains/response types
                 self.check_model_applicability(pre_model)
+
+                # Only use the model's name if no override is specified
+                model_name = modelinfo.override_name
+                if not model_name:
+                    model_name = pre_model.name
+
+                # Ensure that names are unique and show a warning if duplicates are detected
+                original_model_name = model_name
+                changed = False
+                while model_name in model_name_cache:
+                    model_name = model_name + '\''
+                    changed = True
+                model_name_cache.add(model_name)
+
+                if changed:
+                    warnings.warn('Duplicate model name detected ("{}"). Changed to "{}".'.format(
+                        original_model_name, model_name))
 
                 # Only perform general pre-training if training data is
                 # supplied and corresponding data is false. Otherwise, the
@@ -473,6 +484,7 @@ class LC_Evaluator(Evaluator):
                 if self.train_data is not None and not self.corresponding_data:
                     # Prepare training data
                     pre_model.pre_train(list(train_data_dict.values()))
+
 
                 # Iterate subject
                 for subj_id, subj_df in self.test_data.get().groupby('id'):

--- a/ccobra/benchmark/evaluator.py
+++ b/ccobra/benchmark/evaluator.py
@@ -548,7 +548,7 @@ class LC_Evaluator(Evaluator):
 
                         model_evaluations[subj_id][
                             'main_train'].append(self.evaluate_checkpoints(
-                                [copy.deepcopy(model)], subj_id))
+                                [copy.deepcopy(model)], subj_id)[0])
 
                         result_data.append({
                             'model': model.name,

--- a/ccobra/benchmark/evaluator.py
+++ b/ccobra/benchmark/evaluator.py
@@ -685,7 +685,7 @@ class LC_Evaluator(Evaluator):
         df2.groupby(['Model', 'Subject', 'Epoch', 'Train/Test']).mean()
 
         df2.drop('Item', axis=1, inplace=True)
-        df = pd.concat(df1, df2)
+        df = pd.concat([df1, df2])
 
         sns.set(style='whitegrid')
 

--- a/ccobra/benchmark/evaluator.py
+++ b/ccobra/benchmark/evaluator.py
@@ -682,11 +682,15 @@ class LC_Evaluator(Evaluator):
                                  'Item': item
                                  })
         df2 = pd.DataFrame(data)
-        # average over adaption runs of one model and subject
-        df2.groupby(['Model', 'Subject', 'Epoch', 'Train/Test']).mean()
 
-        df2.drop('Item', axis=1, inplace=True)
-        df = pd.concat([df1, df2])
+        if not df2.empty:
+            # average over adaption runs of one model and subject
+            df2.groupby(['Model', 'Subject', 'Epoch', 'Train/Test']).mean()
+
+            df2.drop('Item', axis=1, inplace=True)
+            df = pd.concat([df1, df2])
+        else:
+            df = df1
 
         sns.set(style='whitegrid')
 

--- a/ccobra/benchmark/evaluator.py
+++ b/ccobra/benchmark/evaluator.py
@@ -768,7 +768,7 @@ class Split_Evaluator(Evaluator):
 
     def __init__(self, modellist, eval_comparator, datafile=None,
                  train_data_person=None, silent=False,
-                 split_ratio=0.5):
+                 split_ratio=0.5, no_pretrain=False):
         """
 
         Parameters
@@ -808,6 +808,8 @@ class Split_Evaluator(Evaluator):
         # Load the data set
         self.data = ccobra.CCobraData(pd.read_csv(datafile))
         self.split_ratio = split_ratio
+
+        self.pretrain = not no_pretrain
 
         # Load the personal training data
         self.train_data_person = None
@@ -903,7 +905,8 @@ class Split_Evaluator(Evaluator):
                         value for key, value in train_data_dict.items() if key != subj_id]
 
                     # Train on incomplete training data
-                    model.pre_train(cur_train_data_dict)
+                    if self.pretrain:
+                        model.pre_train(cur_train_data_dict)
 
                     # Perform the personalized pre-training
                     if self.train_data_person is not None:

--- a/ccobra/benchmark/evaluator.py
+++ b/ccobra/benchmark/evaluator.py
@@ -53,7 +53,8 @@ class Evaluator():
     """
 
     def __init__(self, modellist, eval_comparator, test_datafile, train_datafile=None,
-                 train_data_person=None, silent=False, corresponding_data=False):
+                 train_data_person=None, silent=False, corresponding_data=False,
+                 no_adapt=False):
         """
 
         Parameters
@@ -81,6 +82,8 @@ class Evaluator():
             user ids.
 
         """
+
+        self.adapt = not no_adapt
 
         self.modellist = modellist
         self.silent = silent
@@ -383,7 +386,8 @@ class Evaluator():
                         adapt_item = ccobra.data.Item(
                             subj_id, domain, task, response_type, choices,
                             sequence)
-                        model.adapt(adapt_item, truth, **optionals)
+                        if self.adapt:
+                            model.adapt(adapt_item, truth, **optionals)
 
                         # Collect the evaluation result data
                         result_data.append({
@@ -583,9 +587,10 @@ class LC_Evaluator(Evaluator):
                         adapt_item = ccobra.data.Item(
                             subj_id, domain, task, response_type, choices,
                             sequence)
-                        model.adapt(adapt_item, truth,
-                                    checkpoints=model_checkpoints,
-                                    **optionals)
+                        if self.adapt:
+                            model.adapt(adapt_item, truth,
+                                        checkpoints=model_checkpoints,
+                                        **optionals)
 
                         if adapt_str in self.learning_curves_for:
                             model_evaluations[subj_id][adapt_str][
@@ -768,7 +773,7 @@ class Split_Evaluator(Evaluator):
 
     def __init__(self, modellist, eval_comparator, datafile=None,
                  train_data_person=None, silent=False,
-                 split_ratio=0.5, no_pretrain=False):
+                 split_ratio=0.5, no_pretrain=False, no_adapt=False):
         """
 
         Parameters
@@ -796,6 +801,8 @@ class Split_Evaluator(Evaluator):
             user ids.
 
         """
+
+        self.adapt = not no_adapt
 
         self.modellist = modellist
         self.silent = silent

--- a/ccobra/benchmark/runner.py
+++ b/ccobra/benchmark/runner.py
@@ -170,8 +170,11 @@ def main(args):
         html = htmlcrtr.to_html(res_df, args['benchmark'], embedded=False)
         # redirect to file
         if args['html_file']:
-            with open(args['html_file'], 'w') as f:
-                f.write(html)
+            try:
+                with open(args['html_file'], 'w') as f:
+                    f.write(html)
+            except:
+                print(html)
         else:
             print(html)
 

--- a/ccobra/benchmark/runner.py
+++ b/ccobra/benchmark/runner.py
@@ -170,7 +170,7 @@ def main(args):
         html = htmlcrtr.to_html(res_df, args['benchmark'], embedded=False)
         # redirect to file
         if args['html_file']:
-            with open(args['html_file'], 'r') as f:
+            with open(args['html_file'], 'w') as f:
                 f.write(html)
         else:
             print(html)

--- a/ccobra/benchmark/runner.py
+++ b/ccobra/benchmark/runner.py
@@ -51,6 +51,9 @@ def parse_arguments():
                         'person_train). Enter as list without seperator.',
                         default=['main_train', 'pre_train', 'adapt',
                                  'start_participant', 'person_train'])
+    parser.add_argument('--html_file', type=str,
+                        help='File in which to store the html content.'
+                             ' To seperate from model logs for debugging.')
 
     args = vars(parser.parse_args())
 
@@ -120,7 +123,7 @@ def main(args):
             eval_comparator = comparator.NVCComparator()
 
     # Run the model evaluation
-    is_silent = (args['output'] in ['html', 'server'])
+    is_silent = (args['output'] in ['server'])
     if args['learning_curves_folder']:
         eva = evaluator.LC_Evaluator(
                 modellist,
@@ -165,7 +168,12 @@ def main(args):
         sys.stdout.buffer.write(html.encode('utf-8'))
     elif args['output'] == 'html':
         html = htmlcrtr.to_html(res_df, args['benchmark'], embedded=False)
-        print(html)
+        # redirect to file
+        if args['html_file']:
+            with open(args['html_file'], 'r') as f:
+                f.write(html)
+        else:
+            print(html)
 
 def entry_point():
     """ Entry point for the CCOBRA executables.

--- a/ccobra/benchmark/runner.py
+++ b/ccobra/benchmark/runner.py
@@ -51,6 +51,9 @@ def parse_arguments():
                         'person_train). Enter as list without seperator.',
                         default=['main_train', 'pre_train', 'adapt',
                                  'start_participant', 'person_train'])
+    parser.add_argument('--evaluation_frequency', type=int,
+                        help='How frequently to evaluate the model for the '
+                        'learning curve generation.', default=1)
     parser.add_argument('--html_file', type=str,
                         help='File in which to store the html content.'
                              ' To seperate from model logs for debugging.')
@@ -156,7 +159,8 @@ def main(args):
                 corresponding_data=corresponding_data,
                 learning_curves_folder=args['learning_curves_folder'],
                 learning_curves_for=args['learning_curves_for'],
-                no_adapt=args['no_adapt']
+                no_adapt=args['no_adapt'],
+                evaluation_frequency=args['evaluation_frequency']
                 )
     else:
         eva = evaluator.Evaluator(

--- a/ccobra/benchmark/runner.py
+++ b/ccobra/benchmark/runner.py
@@ -59,6 +59,9 @@ def parse_arguments():
                         action='store_true')
     parser.add_argument('--split_ratio', type=float, default=0.6,
                         help='Split ratio for the split evaluator.')
+    parser.add_argument('--no_pretrain', help='Flag to deactivate pretraining '
+                        'when using the split evaluator.',
+                        action='store_true')
 
     args = vars(parser.parse_args())
 
@@ -137,7 +140,8 @@ def main(args):
                 datafile=benchmark['data.test'],
                 train_data_person=benchmark['data.train_person'],
                 silent=is_silent,
-                split_ratio=args['split_ratio']
+                split_ratio=args['split_ratio'],
+                no_pretrain=args['no_pretrain']
             )
     elif args['learning_curves_folder']:
         eva = evaluator.LC_Evaluator(

--- a/ccobra/benchmark/runner.py
+++ b/ccobra/benchmark/runner.py
@@ -117,15 +117,27 @@ def main(args):
 
     # Run the model evaluation
     is_silent = (args['output'] in ['html', 'server'])
-    eva = evaluator.Evaluator(
-        modeldict,
-        eval_comparator,
-        benchmark['data.test'],
-        train_datafile=benchmark['data.train'],
-        train_data_person=benchmark['data.train_person'],
-        silent=is_silent,
-        corresponding_data=corresponding_data,
-        learning_curves=args['learning_curves'])
+    if args['learning_curves']:
+        eva = evaluator.LC_Evaluator(
+                modeldict,
+                eval_comparator,
+                benchmark['data.test'],
+                train_datafile=benchmark['data.train'],
+                train_data_person=benchmark['data.train_person'],
+                silent=is_silent,
+                corresponding_data=corresponding_data,
+                learning_curves=args['learning_curves']
+                )
+    else:
+        eva = evaluator.Evaluator(
+                modeldict,
+                eval_comparator,
+                benchmark['data.test'],
+                train_datafile=benchmark['data.train'],
+                train_data_person=benchmark['data.train_person'],
+                silent=is_silent,
+                corresponding_data=corresponding_data,
+            )
 
     with silence_stdout(is_silent):
         res_df = eva.evaluate()

--- a/ccobra/benchmark/runner.py
+++ b/ccobra/benchmark/runner.py
@@ -54,6 +54,11 @@ def parse_arguments():
     parser.add_argument('--html_file', type=str,
                         help='File in which to store the html content.'
                              ' To seperate from model logs for debugging.')
+    parser.add_argument('--split_evaluator', help='Flag to use the split eval'
+                        'uator. Use with just train datafile! No LC gen!',
+                        action='store_true')
+    parser.add_argument('--split_ratio', type=float, default=0.6,
+                        help='Split ratio for the split evaluator.')
 
     args = vars(parser.parse_args())
 
@@ -124,7 +129,17 @@ def main(args):
 
     # Run the model evaluation
     is_silent = (args['output'] in ['server'])
-    if args['learning_curves_folder']:
+
+    if args['split_evaluator']:
+        eva = evaluator.Split_Evaluator(
+                modellist,
+                eval_comparator,
+                datafile=benchmark['data.test'],
+                train_data_person=benchmark['data.train_person'],
+                silent=is_silent,
+                split_ratio=args['split_ratio']
+            )
+    elif args['learning_curves_folder']:
         eva = evaluator.LC_Evaluator(
                 modellist,
                 eval_comparator,

--- a/ccobra/benchmark/runner.py
+++ b/ccobra/benchmark/runner.py
@@ -41,6 +41,10 @@ def parse_arguments():
     parser.add_argument(
         '-cn', '--classname', type=str,
         help='Load a specific class from a folder containing multiple classes.')
+    parser.add_argument('--learning_curves', type=str,
+                        help='Generate learning curves for the models and save'
+                        'in the specified folder. This is expensive, since '
+                        'rollouts are performed every training epoch.')
 
     args = vars(parser.parse_args())
 
@@ -120,7 +124,8 @@ def main(args):
         train_datafile=benchmark['data.train'],
         train_data_person=benchmark['data.train_person'],
         silent=is_silent,
-        corresponding_data=corresponding_data)
+        corresponding_data=corresponding_data,
+        learning_curves=args['learning_curves'])
 
     with silence_stdout(is_silent):
         res_df = eva.evaluate()

--- a/ccobra/benchmark/runner.py
+++ b/ccobra/benchmark/runner.py
@@ -41,10 +41,16 @@ def parse_arguments():
     parser.add_argument(
         '-cn', '--classname', type=str,
         help='Load a specific class from a folder containing multiple classes.')
-    parser.add_argument('--learning_curves', type=str,
+    parser.add_argument('--learning_curves_folder', type=str,
                         help='Generate learning curves for the models and save'
                         'in the specified folder. This is expensive, since '
                         'rollouts are performed every training epoch.')
+    parser.add_argument('--learning_curves_for', type=str, nargs='+',
+                        help='The phases to generate learning curves for '
+                        '(main_train, pre_train, adapt, start_participant, '
+                        'person_train). Enter as list without seperator.',
+                        default=['main_train', 'pre_train', 'adapt',
+                                 'start_participant', 'person_train'])
 
     args = vars(parser.parse_args())
 
@@ -117,7 +123,7 @@ def main(args):
 
     # Run the model evaluation
     is_silent = (args['output'] in ['html', 'server'])
-    if args['learning_curves']:
+    if args['learning_curves_folder']:
         eva = evaluator.LC_Evaluator(
                 modeldict,
                 eval_comparator,
@@ -126,7 +132,8 @@ def main(args):
                 train_data_person=benchmark['data.train_person'],
                 silent=is_silent,
                 corresponding_data=corresponding_data,
-                learning_curves=args['learning_curves']
+                learning_curves_folder=args['learning_curves_folder'],
+                learning_curves_for=args['learning_curves_for']
                 )
     else:
         eva = evaluator.Evaluator(

--- a/ccobra/benchmark/runner.py
+++ b/ccobra/benchmark/runner.py
@@ -62,6 +62,9 @@ def parse_arguments():
     parser.add_argument('--no_pretrain', help='Flag to deactivate pretraining '
                         'when using the split evaluator.',
                         action='store_true')
+    parser.add_argument('--no_adapt', help='Flag to deactivate model-adapt.'
+                        'Redundant for split evaluator.',
+                        action='store_true')
 
     args = vars(parser.parse_args())
 
@@ -141,7 +144,6 @@ def main(args):
                 train_data_person=benchmark['data.train_person'],
                 silent=is_silent,
                 split_ratio=args['split_ratio'],
-                no_pretrain=args['no_pretrain']
             )
     elif args['learning_curves_folder']:
         eva = evaluator.LC_Evaluator(
@@ -153,7 +155,8 @@ def main(args):
                 silent=is_silent,
                 corresponding_data=corresponding_data,
                 learning_curves_folder=args['learning_curves_folder'],
-                learning_curves_for=args['learning_curves_for']
+                learning_curves_for=args['learning_curves_for'],
+                no_adapt=args['no_adapt']
                 )
     else:
         eva = evaluator.Evaluator(
@@ -164,6 +167,7 @@ def main(args):
                 train_data_person=benchmark['data.train_person'],
                 silent=is_silent,
                 corresponding_data=corresponding_data,
+                no_adapt=args['no_adapt']
             )
 
     with silence_stdout(is_silent):

--- a/ccobra/model.py
+++ b/ccobra/model.py
@@ -42,7 +42,7 @@ class CCobraModel():
 
         pass
 
-    def pre_train(self, dataset):
+    def pre_train(self, dataset, **kwargs):
         """ Pre-trains the model based on given training data.
 
         Parameters
@@ -57,7 +57,7 @@ class CCobraModel():
 
         pass
 
-    def person_train(self, data):
+    def person_train(self, data, **kwargs):
         """ Trains the model based on background data of the individual to
         be tested on.
 


### PR DESCRIPTION
_Hint_: This pull request is designed as a feature request paired with an example implementation, not necessarily to directly pull it.

It would be nice if ccobra could automatically generate learning curves for the models so that one can get a sense for the learning process.

I have made an example implementation of such feature by creating model checkpoints every training epoch during both pre-training and adaption. 
If the corresponding argument is provided to the runner, all the created model checkpoints will be evaluated and learning curves are generated at the end of the run.
In my implementation the plots are made using seaborn and directly saved to the local drive.
Of course, it would be more in line with the general design to display the plots as part of the HTML-report.